### PR TITLE
[Release] 0.6.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: |
-            my-docker-hub-namespace/my-docker-hub-repository
+            studiometa/test-redirection
             ghcr.io/${{ github.repository }}
 
       - name: Build and push Docker images

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## v0.6.1 (2023-10-27)
+
+### Fixed
+
+- Fix Docker image name in GitHub Action ([79416e0](https://github.com/studiometa/cli-test-redirection/commit/79416e0))
+
 ## v0.6.0 (2023-10-27)
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/cli-test-redirection",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/cli-test-redirection",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "cac": "^6.7.12",
         "chalk": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/cli-test-redirection",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
### Fixed

- Fix Docker image name in GitHub Action ([79416e0](https://github.com/studiometa/cli-test-redirection/commit/79416e0))